### PR TITLE
Fix doc shortcut display font name

### DIFF
--- a/foundry.lua
+++ b/foundry.lua
@@ -1,7 +1,7 @@
 -- foundry - view norns fonts
 --
 -- E1 at any time to change font
---    hold E1 to see font names
+--    hold K1 to see font names
 --
 -- K3 descends down a UI level
 -- K2 ascends up a UI level


### PR DESCRIPTION
There was a minor typo in the doc.

`K1` (and not `E1`) has to be held to see the font names.